### PR TITLE
Fix Windows build errors

### DIFF
--- a/ffmpegServerApp/src/Makefile
+++ b/ffmpegServerApp/src/Makefile
@@ -46,6 +46,9 @@ USR_INCLUDES += -I$(TOP)/vendor/ffmpeg-$(VENDORARCH)/include
 		
 # build the ffmpeg libs (or stubs on windows) into the binaries
 ffmpegServer_LIBS += avdevice avformat avcodec avutil swscale
+ffmpegServer_LIBS += ADBase NDPlugin asyn
+ffmpegServer_LIBS += $(EPICS_BASE_IOC_LIBS)
+ffmpegServer_SYS_LIBS_WIN32 += user32
 		
 # The following are compiled and added to the support library
 ffmpegServer_SRCS += ffmpegCommon.cpp


### PR DESCRIPTION
Fix "unresolved external symbol" link errors on Windows.