### PR TITLE
Fix WIN32 compile errors due to Winsock conflicts

### DIFF
--- a/ffmpegServerApp/src/nullhttpd.h
+++ b/ffmpegServerApp/src/nullhttpd.h
@@ -29,8 +29,11 @@
 //	#pragma comment(lib, "libcmt.lib")
 	#pragma comment(lib, "ws2_32.lib")
 //	#define _MT 1
-	#include <winsock.h>
+	#define WIN32_LEAN_AND_MEAN
 	#include <windows.h>
+	#include <winsock2.h>
+	#include <mstcpip.h>
+	#include <ws2tcpip.h>
 	#include <process.h>
 	#include <shellapi.h>
 	#include <signal.h>

--- a/ffmpegServerApp/src/nullhttpd_server.c
+++ b/ffmpegServerApp/src/nullhttpd_server.c
@@ -19,8 +19,6 @@
 #include "nullhttpd.h"
 
 #ifdef WIN32
-#include "Mstcpip.h"
-#include "ws2tcpip.h"
 static WSADATA wsaData;
 #define socklen_t int
 static SOCKET ListenSocket;


### PR DESCRIPTION
Fix Winsock compile errors like:

  ws2def.h(212) : error C2011: 'sockaddr' : 'struct' type redefinition

By default, windows.h includes winsock.h which is for Windows Sockets
1.1.  This will conflict with including winsock2.h which is for Windows
Sockets 2.0.  Defining WIN32_LEAN_AND_MEAN makes windows.h not include
winsock.h.  (This could also have been worked around by including
winsock2.h before windows.h.)  There are also special orderings required
for Winsock-related include files.  For more information, see:

  https://docs.microsoft.com/en-us/windows/desktop/winsock/creating-a-basic-winsock-application