### PR TITLE
Allow for specifying network interface to bind to using new iocsh func

### DIFF
--- a/ffmpegServerApp/src/ffmpegServer.cpp
+++ b/ffmpegServerApp/src/ffmpegServer.cpp
@@ -184,18 +184,21 @@ void c_shutdown(void *) {
 }    
 
 
-/** Configure and start the http server, specifying a specific network interface, or 'any' for default
- * Default port is 8080
+/** Configure and start the http server, specifying a specific network interface, or 'any' for default.
+ * To specify an interface, use either the DNS name or the IP of the NIC. ex: 10.68.212.33 or my-ioc-server-hostname
+ * Default port is 8080. 
  */
-void ffmpegServerConfigWithInterface(int port, const char* networkInterface) {
+void ffmpegServerConfigure(int port, const char* networkInterface) {
     int status;
     if (port==0) {
         port = 8080;
-    }    
+    }
+
     streams = (ffmpegStream **) calloc(MAX_FFMPEG_STREAMS, sizeof(ffmpegStream *));
     nstreams = 0;    
     config.server_port = port;
     config.server_loglevel=1;
+    
     strncpy(config.server_hostname, networkInterface, sizeof(config.server_hostname)-1);
     config.server_maxconn=50;
     config.server_maxidle=120;    
@@ -221,15 +224,6 @@ void ffmpegServerConfigWithInterface(int port, const char* networkInterface) {
     } else printf("OK\n");
     /* Register the shutdown function for epicsAtExit */
     epicsAtExit(c_shutdown, NULL);    
-}
-
-/** Configure and start the http server.
-Call this before creating any instances of ffmpegStream
-\param port port number to run the server on. Defaults to 8080
-*/
-void ffmpegServerConfigure(int port) {
-
-    ffmpegServerConfigWithInterface(port, "any");
 }
 
 /** Internal function to send a single snapshot */
@@ -730,30 +724,25 @@ static void streamCallFunc(const iocshArgBuf *args)
 }
 
 static const iocshArg serverArg0 = { "Http Port",iocshArgInt};
-static const iocshArg * const serverArgs[] = {&serverArg0};
-static const iocshFuncDef serverFuncDef = {"ffmpegServerConfigure",1,serverArgs};
+static const iocshArg serverArg1 = { "Network Interface", iocshArgString};
+static const iocshArg * const serverArgs[] = {&serverArg0, &serverArg1};
+static const iocshFuncDef serverFuncDef = {"ffmpegServerConfigure",2,serverArgs};
 
-static const iocshArg serverWithInterfaceArg0 = { "Http Port", iocshArgInt};
-static const iocshArg serverWithInterfaceArg1 = { "Network Interface", iocshArgString};
-static const iocshArg * const serverWithInterfaceArgs[] = {&serverWithInterfaceArg0, &serverWithInterfaceArg1};
-static const iocshFuncDef serverWithInterfaceFuncDef = {"ffmpegServerConfigWithInterface",2,serverWithInterfaceArgs};
 
 static void serverCallFunc(const iocshArgBuf *args)
 {
-    ffmpegServerConfigure(args[0].ival);
+    if(args[1].sval == NULL)
+        ffmpegServerConfigure(args[0].ival, "any");
+    else
+        ffmpegServerConfigure(args[0].ival, args[1].sval);
 }
 
-static void serverWithInterfaceCallFunc(const iocshArgBuf *args)
-{
-    ffmpegServerConfigWithInterface(args[0].ival, args[1].sval);
-}
 
 /** Register ffmpegStreamConfigure and ffmpegServerConfigure for use on iocsh */
 extern "C" void ffmpegServerRegister(void)
 {
     iocshRegister(&streamFuncDef,streamCallFunc);
     iocshRegister(&serverFuncDef,serverCallFunc);
-    iocshRegister(&serverWithInterfaceFuncDef,serverWithInterfaceCallFunc);
 }
 
 extern "C" {


### PR DESCRIPTION
This PR adds another ioc shell function in addition to `ffmpegServerConfigure`, called `ffmpegServerConfigWithInterface`. This allows for passing in an additional argument that specifies the network interface IP to bind the http server to. At NSLS2 this will be used to keep the ffmpegServer ports out of the view of the cybersec scanner that was causing them to lock up and kill their parent IOCs.

The original `ffmpegServerConfigure` function should continue to work as before.