### PR TITLE
Fix for build error: multiple variable definitions

### DIFF
--- a/ffmpegServerApp/src/Makefile
+++ b/ffmpegServerApp/src/Makefile
@@ -48,7 +48,7 @@ LIB_SYS_LIBS_WIN32 += user32
 		
 # The following are compiled and added to the support library
 ffmpegServer_SRCS += ffmpegCommon.cpp
-ffmpegServer_SRCS += ffmpegServer.cpp nullhttpd_server.c nullhttpd_http.c nullhttpd_format.c nullhttpd_win32.c
+ffmpegServer_SRCS += ffmpegServer.cpp nullhttpd_extern.c nullhttpd_server.c nullhttpd_http.c nullhttpd_format.c nullhttpd_win32.c
 ffmpegServer_SRCS += ffmpegFile.cpp
 
 include $(ADCORE)/ADApp/commonLibraryMakefile

--- a/ffmpegServerApp/src/nullhttpd.h
+++ b/ffmpegServerApp/src/nullhttpd.h
@@ -226,14 +226,15 @@ typedef struct {
 #ifdef WIN32
 HINSTANCE hInst;
 #endif
-struct {
+typedef struct {
 	pthread_mutex_t Crypt;
 	pthread_mutex_t Global;
 	pthread_mutex_t SQL;
-} Lock;
-char program_name[255];
-CONFIG config;
-CONNECTION *conn;
+} LOCK;
+extern LOCK Lock;
+extern char program_name[255];
+extern CONFIG config;
+extern CONNECTION *conn;
 
 /* function forwards */
 /* win32.c functions */

--- a/ffmpegServerApp/src/nullhttpd_extern.c
+++ b/ffmpegServerApp/src/nullhttpd_extern.c
@@ -1,0 +1,6 @@
+#include "nullhttpd.h"
+
+extern CONFIG config;
+extern CONNECTION *conn;
+extern LOCK Lock;
+char program_name[255];

--- a/ffmpegServerApp/src/nullhttpd_extern.c
+++ b/ffmpegServerApp/src/nullhttpd_extern.c
@@ -1,6 +1,6 @@
 #include "nullhttpd.h"
 
-extern CONFIG config;
-extern CONNECTION *conn;
-extern LOCK Lock;
+CONFIG config;
+CONNECTION *conn;
+LOCK Lock;
 char program_name[255];


### PR DESCRIPTION
`ffmpegServer` fails to build with gcc 11.4 (the default version for RHEL 9.2) reporting multiple definitions of variables `config`, `conn`, `Lock` and `program_name`. This PR provides a fix for this error.

Originally, the variables were defined in the file `nullhttpd.h`, which was included in multiple `.c` files, resulting in multiple definitions of global variables. Older versions of gcc (e.g. gcc 8.5) are ignoring the issue by default and allocate shared global variables. 

Changes:

- Global variable definitions are moved from `nullhttpd.h` to a new file `nullhttpd_extern.c`. 
- Global variable definitions in `nullhttpd.h` are replaced by declarations of external variables.
- Additional type `LOCK` is added to `nullhttpd.h`.
- The file `nullhttpd_extern.c` is added to the list of source files in `Makefile`.

The proposed changes are not expected to affect the behavior of the code.
