### PR TITLE
Fix deprecated api

### DIFF
--- a/ffmpegServerApp/src/ffmpegCommon.cpp
+++ b/ffmpegServerApp/src/ffmpegCommon.cpp
@@ -8,12 +8,6 @@ void ffmpegInitialise() {
 	/* check if we're already intialised */
 	if (ffmpegInitialised) return;
 	
-    /* register all the codecs */
-    avcodec_register_all();
-
-	/* start the library */
-    av_register_all();	
-    
     /* Make a big neutral array */
     neutral = (unsigned char *)malloc(NEUTRAL_FRAME_SIZE *  sizeof(unsigned char));
     memset(neutral, 128, NEUTRAL_FRAME_SIZE);           

--- a/ffmpegServerApp/src/ffmpegCommon.h
+++ b/ffmpegServerApp/src/ffmpegCommon.h
@@ -10,6 +10,7 @@ extern "C" {
 #include "libavcodec/avcodec.h"
 #include "libswscale/swscale.h"
 #include "libavformat/avformat.h"
+#include "libavutil/imgutils.h"
 }
 
 /* areaDetector includes */

--- a/ffmpegServerApp/src/ffmpegFile.h
+++ b/ffmpegServerApp/src/ffmpegFile.h
@@ -41,19 +41,19 @@ protected:
 
 private:
     FILE *outFile;
-    AVCodec *codec;
+    const AVCodec *codec;
     enum AVCodecID codec_id;
     AVCodecContext *c;
     AVFrame *inPicture;
     AVFrame *scPicture;    
     NDArray *scArray;
     NDArray *outArray;
+    AVPacket *pkt;
     struct SwsContext *ctx;      
     size_t outSize;
     int needStop;      
     int sheight, swidth;
     enum AVPixelFormat spix_fmt;
-    AVOutputFormat *fmt;
     AVFormatContext *oc;
     AVStream *video_st;
     double video_pts;   

--- a/ffmpegServerApp/src/ffmpegServer.cpp
+++ b/ffmpegServerApp/src/ffmpegServer.cpp
@@ -468,8 +468,7 @@ void ffmpegStream::processCallbacks(NDArray *pArray)
         avr.den = 25;
         if (c != NULL) {
             /* width and height changed, close old codec */
-            avcodec_close(c);
-            av_free(c);
+            avcodec_free_context(&c);
         }
         c = avcodec_alloc_context3(codec);
         /* Make sure that we don't try and create an image smaller than AV_INPUT_BUFFER_MIN_SIZE */

--- a/ffmpegServerApp/src/ffmpegServer.cpp
+++ b/ffmpegServerApp/src/ffmpegServer.cpp
@@ -357,7 +357,7 @@ void ffmpegStream::allocScArray(size_t size) {
     if (this->scArray) {
         if (this->scArray->dims[0].size >= size) {
             /* the processed array is already big enough */
-            avpicture_fill((AVPicture *)scPicture,(uint8_t *)scArray->pData,c->pix_fmt,c->width,c->height);               
+            av_image_fill_arrays(scPicture->data,scPicture->linesize,(uint8_t *)scArray->pData,c->pix_fmt,c->width,c->height,1);
             return;
         } else {
             /* need a new one, so discard the old one */
@@ -366,7 +366,7 @@ void ffmpegStream::allocScArray(size_t size) {
     }
     this->scArray = this->pNDArrayPool->alloc(1, &size, NDInt8, 0, NULL);
     /* alloc in and scaled pictures */
-    avpicture_fill((AVPicture *)scPicture,(uint8_t *)scArray->pData,c->pix_fmt,c->width,c->height);   
+    av_image_fill_arrays(scPicture->data,scPicture->linesize,(uint8_t *)scArray->pData,c->pix_fmt,c->width,c->height,1);
 }       
     
 
@@ -384,6 +384,11 @@ void ffmpegStream::processCallbacks(NDArray *pArray)
     int width, height;
     /* in case we force a final size */
     int setw, seth;
+    int num_bytes = 0;
+    AVPacket *pkt = NULL;
+    NDArray *pScratch = NULL;
+    int ret;
+	char errbuf[AV_ERROR_MAX_STRING_SIZE];
 
     size_t size;
     /* for printing errors */
@@ -527,36 +532,42 @@ void ffmpegStream::processCallbacks(NDArray *pArray)
     /* lock the output plugin mutex */
     pthread_mutex_lock(&this->mutex);
 
+    /* send the frame to the encoder */
+    ret = avcodec_send_frame(c, scPicture);
+    if (ret < 0) {
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+            "%s:%s Error sending a frame to the encoder: %s\n",
+            driverName, functionName, av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, ret));
+        goto done;
+    }
+
+    /* allocate a new NDArray for encoded packet */
+    pScratch = this->pNDArrayPool->alloc(1, &size, NDInt8, 0, NULL);
+
+    pkt = av_packet_alloc();
+    while (ret >= 0) {
+        ret = avcodec_receive_packet(c, pkt);
+        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+            break;
+        else if (ret < 0) {
+            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s:%s Error encoding a frame: %s\n",
+                driverName, functionName, av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, ret));
+            pScratch->release();
+            goto done;
+        }
+        memcpy((char*)pScratch->pData + num_bytes, pkt->data, pkt->size);
+        num_bytes += pkt->size;
+
+        av_packet_unref(pkt);
+    }
+    pScratch->dims[0].size = num_bytes;
+
     /* Release the last jpeg created */
     if (this->jpeg) {
         this->jpeg->release();
     }
-    
-    /* Convert it to a jpeg */        
-    this->jpeg = this->pNDArrayPool->alloc(1, &size, NDInt8, 0, NULL);
-
-    AVPacket pkt;
-    int got_output;
-    av_init_packet(&pkt);
-    pkt.data = (uint8_t*)this->jpeg->pData;    // packet data will be allocated by the encoder
-    pkt.size = c->width * c->height;
-
-    // needed to stop a stream of "AVFrame.format is not set" etc. messages
-    scPicture->format = c->pix_fmt;
-    scPicture->width = c->width;
-    scPicture->height = c->height;
-
-    if (avcodec_encode_video2(c, &pkt, scPicture, &got_output)) {
-        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-            "%s:%s: Encoding jpeg failed\n",
-            driverName, functionName);
-        got_output = 0; // got_output is undefined on error, so explicitly set it for use later
-    }
-
-    if (got_output) {
-        this->jpeg->dims[0].size = pkt.size;
-        av_packet_unref(&pkt);
-    }
+    this->jpeg = pScratch;
 
     //printf("Frame! Size: %d\n", this->jpeg->dims[0].size);
     
@@ -564,6 +575,9 @@ void ffmpegStream::processCallbacks(NDArray *pArray)
     for (int i=0; i<config.server_maxconn; i++) {
         pthread_cond_signal(&(this->cond[i]));
     }
+
+done:
+    av_packet_free(&pkt);
     pthread_mutex_unlock(&this->mutex);
 
     /* We must enter the loop and exit with the mutex locked */

--- a/ffmpegServerApp/src/ffmpegServer.h
+++ b/ffmpegServerApp/src/ffmpegServer.h
@@ -66,7 +66,7 @@ private:
     NDArray *jpeg;
     int nclients;
          
-    AVCodec *codec;
+    const AVCodec *codec;
     AVCodecContext *c;
     AVFrame *inPicture;
     AVFrame *scPicture;            

--- a/ffmpegServerApp/src/nullhttpd.h
+++ b/ffmpegServerApp/src/nullhttpd.h
@@ -274,17 +274,17 @@ void fixslashes(char *pOriginal);
 int hex2int(char *pChars);
 void striprn(char *string);
 void swapchar(char *string, char oldchar, char newchar);
-char *nullhttpd_strcasestr(const char *src, const char *query);
+const char *nullhttpd_strcasestr(const char *src, const char *query);
 char *strcatf(char *dest, const char *format, ...);
 int printhex(const char *format, ...);
 int printht(const char *format, ...);
 /* http.c functions */
-void printerror(int sid, int status, char* title, char* text);
+void printerror(int sid, int status, const char* title, const char* text);
 char *get_mime_type(char *name);
 void ReadPOSTData(int sid);
 int read_header(int sid);
-void send_header(int sid, int cacheable, int status, char *title, char *extra_header, char *mime_type, int length, time_t mod);
-void send_fileheader(int sid, int cacheable, int status, char *title, char *extra_header, char *mime_type, int length, time_t mod);
+void send_header(int sid, int cacheable, int status, const char *title, const char *extra_header, const char *mime_type, int length, time_t mod);
+void send_fileheader(int sid, int cacheable, int status, const char *title, const char *extra_header, const char *mime_type, int length, time_t mod);
 /* server.c functions */
 void logaccess(int loglevel, const char *format, ...);
 void logerror(const char *format, ...);

--- a/ffmpegServerApp/src/nullhttpd_format.c
+++ b/ffmpegServerApp/src/nullhttpd_format.c
@@ -92,7 +92,7 @@ void swapchar(char *string, char oldchar, char newchar)
 	}
 }
 
-char *nullhttpd_strcasestr(const char *src, const char *query)
+const char *nullhttpd_strcasestr(const char *src, const char *query)
 {
 	char *pToken;
 	char Buffer[8192];

--- a/ffmpegServerApp/src/nullhttpd_http.c
+++ b/ffmpegServerApp/src/nullhttpd_http.c
@@ -20,7 +20,7 @@
 
 #define RFC1123FMT "%a, %d %b %Y %H:%M:%S GMT"
 
-void printerror(int sid, int status, char* title, char* text)
+void printerror(int sid, int status, const char* title, const char* text)
 {
 	send_header(sid, 0, 200, "OK", "1", "text/html", -1, -1);
 	prints("<HTML><HEAD><TITLE>%d %s</TITLE></HEAD>\n", status, title);
@@ -197,7 +197,7 @@ logdata("\n[[[ STARTING REQUEST ]]]\n");
 	return 0;
 }
 
-void send_header(int sid, int cacheable, int status, char *title, char *extra_header, char *mime_type, int length, time_t mod)
+void send_header(int sid, int cacheable, int status, const char *title, const char *extra_header, const char *mime_type, int length, time_t mod)
 {
 	char timebuf[100];
 	time_t now;
@@ -232,7 +232,7 @@ void send_header(int sid, int cacheable, int status, char *title, char *extra_he
 	}
 }
 
-void send_fileheader(int sid, int cacheable, int status, char *title, char *extra_header, char *mime_type, int length, time_t mod)
+void send_fileheader(int sid, int cacheable, int status, const char *title, const char *extra_header, const char *mime_type, int length, time_t mod)
 {
 	char timebuf[100];
 	time_t now;

--- a/ffmpegServerApp/src/nullhttpd_server.c
+++ b/ffmpegServerApp/src/nullhttpd_server.c
@@ -543,7 +543,7 @@ void WSAReaper(void *x)
 #ifdef WIN32
 unsigned _stdcall htloop(void *x)
 #else
-unsigned htloop(void *x)
+void* htloop(void *x)
 #endif
 {
 	int sid=(int)x;


### PR DESCRIPTION
This addresses issue #36. Those APIs have been deprecated since FFmpeg 4 and removed in FFmpeg 5.

This fix has been tested on both FFmpeg versions..