### PR TITLE
Fix rectangle zorder and some texts width

### DIFF
--- a/ffmpegServerApp/op/adl/ffmpegFile.adl
+++ b/ffmpegServerApp/op/adl/ffmpegFile.adl
@@ -87,6 +87,18 @@ display {
 		1a7309,
 	}
 }
+rectangle {
+	object {
+		x=390
+		y=40
+		width=675
+		height=530
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
 "text entry" {
 	object {
 		x=556
@@ -434,18 +446,6 @@ composite {
 				}
 			}
 		}
-	}
-}
-rectangle {
-	object {
-		x=390
-		y=40
-		width=675
-		height=530
-	}
-	"basic attribute" {
-		clr=14
-		fill="outline"
 	}
 }
 composite {
@@ -984,6 +984,18 @@ composite {
 		}
 	}
 }
+rectangle {
+	object {
+		x=390
+		y=575
+		width=675
+		height=70
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
 composite {
 	object {
 		x=477
@@ -1038,9 +1050,9 @@ composite {
 		}
 		text {
 			object {
-				x=779
+				x=749
 				y=586
-				width=30
+				width=60
 				height=20
 			}
 			"basic attribute" {
@@ -1175,18 +1187,6 @@ composite {
 		}
 	}
 }
-rectangle {
-	object {
-		x=390
-		y=575
-		width=675
-		height=100
-	}
-	"basic attribute" {
-		clr=14
-		fill="outline"
-	}
-}
 text {
 	object {
 		x=477
@@ -1232,9 +1232,9 @@ text {
 }
 text {
 	object {
-		x=779
+		x=739
 		y=616
-		width=30
+		width=70
 		height=20
 	}
 	"basic attribute" {

--- a/ffmpegServerApp/op/ui/autoconvert/ffmpegFile.ui
+++ b/ffmpegServerApp/op/ui/autoconvert/ffmpegFile.ui
@@ -15,97 +15,46 @@
 
 QWidget#centralWidget {background: rgba(187, 187, 187, 255);}
 
-caTable {
-       font: 10pt;
-       background: cornsilk;
-       alternate-background-color: wheat;
-}
-
-caLineEdit {
-     border-radius: 1px;
-     background: lightyellow;
-     color: black;
- }
-
-caTextEntry {
-    color: rgb(127, 0, 63);
-    background-color: cornsilk;
-    selection-color: #0a214c;
-    selection-background-color: wheat;
-    border: 1px groove black;
-    border-radius: 1px;
-    padding: 1px;
-}
-
-caTextEntry:focus {
-    padding: 0px;
-    border: 2px groove darkred;
-    border-radius: 1px;
-}
-
-QPushButton {
-      border-color: #00b;
-      border-radius: 2px;
-      padding: 3px;
-      border-width: 1px;
-
-	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-						   stop:0   rgba(224, 239, 255, 255),
-						   stop:0.5 rgba(199, 215, 230, 255),
-						   stop:1   rgba(184, 214, 236, 255));
-}
-QPushButton:hover {
-	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-						stop:0   rgba(201, 226, 255, 255),
-						stop:0.5 rgba(177, 204, 230, 255),
-						stop:1   rgba(163, 205, 236, 255));
-}
-QPushButton:pressed {
-	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-						stop:0   rgba(174, 219, 255, 255),
-						stop:0.5 rgba(165, 199, 230, 255),
-						stop:1   rgba(134, 188, 236, 255));
-}
-
-QPushButton:disabled {
-	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-						stop:0   rgba(174, 219, 255, 255),
-						stop:0.5 rgba(165, 199, 230, 255),
-						stop:1   rgba(134, 188, 236, 255));
-}
-
-caChoice {
-      background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                  stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
-                                  stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
-}
-
-caChoice &gt; QPushButton {
-      text-align: left;
-      padding: 1px;
-}
-
-caSlider::groove:horizontal {
-border: 1px solid #bbb;
-background: lightgrey;
-height: 20px;
-border-radius: 4px;
-}
-
-caSlider::handle:horizontal {
-background: red;
-border: 1px solid #777;
-width: 13px;
-margin-top: -2px;
-margin-bottom: -2px;
-border-radius: 2px;
-}
-
-
-
 </string>
     </property>
     <widget class="QWidget" name="centralWidget">
+        <widget class="caGraphics" name="caRectangle_0">
+            <property name="form">
+                <enum>caGraphics::Rectangle</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>390</x>
+                    <y>40</y>
+                    <width>675</width>
+                    <height>530</height>
+                </rect>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="lineColor">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="linestyle">
+                <enum>Solid</enum>
+            </property>
+        </widget>
         <widget class="caTextEntry" name="caTextEntry_0">
             <property name="geometry">
                 <rect>
@@ -256,7 +205,7 @@ border-radius: 2px;
                     <height>28</height>
                 </rect>
             </property>
-            <widget class="caGraphics" name="caRectangle_0">
+            <widget class="caGraphics" name="caRectangle_1">
                 <property name="form">
                     <enum>caGraphics::Rectangle</enum>
                 </property>
@@ -1019,43 +968,6 @@ border-radius: 2px;
                 </widget>
             </widget>
         </widget>
-        <widget class="caGraphics" name="caRectangle_1">
-            <property name="form">
-                <enum>caGraphics::Rectangle</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>390</x>
-                    <y>40</y>
-                    <width>675</width>
-                    <height>530</height>
-                </rect>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="lineColor">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="linestyle">
-                <enum>Solid</enum>
-            </property>
-        </widget>
         <widget class="caInclude" name="caInclude_7">
             <property name="geometry">
                 <rect>
@@ -1074,7 +986,7 @@ border-radius: 2px;
                 </rect>
             </property>
             <property name="filename">
-                <string>NDPluginBase.adl</string>
+                <string>NDPluginBase.ui</string>
             </property>
             <property name="macro">
                 <string></string>
@@ -2537,6 +2449,43 @@ border-radius: 2px;
                 </property>
             </widget>
         </widget>
+        <widget class="caGraphics" name="caRectangle_2">
+            <property name="form">
+                <enum>caGraphics::Rectangle</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>390</x>
+                    <y>575</y>
+                    <width>675</width>
+                    <height>70</height>
+                </rect>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="lineColor">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="linestyle">
+                <enum>Solid</enum>
+            </property>
+        </widget>
         <widget class="caFrame" name="caFrame_13">
             <property name="geometry">
                 <rect>
@@ -2716,9 +2665,9 @@ border-radius: 2px;
                 </property>
                 <property name="geometry">
                     <rect>
-                        <x>302</x>
+                        <x>272</x>
                         <y>1</y>
-                        <width>30</width>
+                        <width>60</width>
                         <height>20</height>
                     </rect>
                 </property>
@@ -3065,43 +3014,6 @@ border-radius: 2px;
                 </property>
             </widget>
         </widget>
-        <widget class="caGraphics" name="caRectangle_2">
-            <property name="form">
-                <enum>caGraphics::Rectangle</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>390</x>
-                    <y>575</y>
-                    <width>675</width>
-                    <height>100</height>
-                </rect>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="lineColor">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="linestyle">
-                <enum>Solid</enum>
-            </property>
-        </widget>
         <widget class="caLabel" name="caLabel_27">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
@@ -3272,9 +3184,9 @@ border-radius: 2px;
             </property>
             <property name="geometry">
                 <rect>
-                    <x>779</x>
+                    <x>739</x>
                     <y>616</y>
-                    <width>30</width>
+                    <width>70</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -3384,8 +3296,9 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <zorder>caLabel_0</zorder>
         <zorder>caRectangle_0</zorder>
+        <zorder>caLabel_0</zorder>
+        <zorder>caRectangle_1</zorder>
         <zorder>caLabel_1</zorder>
         <zorder>caFrame_0</zorder>
         <zorder>caLabel_2</zorder>
@@ -3399,7 +3312,6 @@ border-radius: 2px;
         <zorder>caLabel_6</zorder>
         <zorder>caFrame_6</zorder>
         <zorder>caFrame_5</zorder>
-        <zorder>caRectangle_1</zorder>
         <zorder>caInclude_7</zorder>
         <zorder>caLabel_7</zorder>
         <zorder>caFrame_8</zorder>
@@ -3418,6 +3330,7 @@ border-radius: 2px;
         <zorder>caLabel_17</zorder>
         <zorder>caLabel_18</zorder>
         <zorder>caFrame_12</zorder>
+        <zorder>caRectangle_2</zorder>
         <zorder>caLabel_19</zorder>
         <zorder>caLabel_20</zorder>
         <zorder>caFrame_13</zorder>
@@ -3429,7 +3342,6 @@ border-radius: 2px;
         <zorder>caFrame_15</zorder>
         <zorder>caLabel_26</zorder>
         <zorder>caFrame_14</zorder>
-        <zorder>caRectangle_2</zorder>
         <zorder>caLabel_27</zorder>
         <zorder>caLabel_28</zorder>
         <zorder>caTextEntry_0</zorder>


### PR DESCRIPTION
Lower the surrounding rectangle z-order, so that the text entries are not blocked in the autoconvered ui files.