### PR TITLE
Bypass scaling skip for mono 8 bit images

### DIFF
--- a/ffmpegServerApp/src/ffmpegCommon.cpp
+++ b/ffmpegServerApp/src/ffmpegCommon.cpp
@@ -54,50 +54,8 @@ int formatArray(NDArray *pArray, asynUser *pasynUser, AVFrame *inPicture,
     if ((pArray->ndims == 2) && (colorMode == NDColorModeMono)) {
         width  = (int) pArray->dims[0].size;
         height = (int) pArray->dims[1].size;
-        if (Int16) {
-            pix_fmt = AV_PIX_FMT_GRAY16;
-        } else if (width != c->width || height != c->height) {
-        	pix_fmt = AV_PIX_FMT_GRAY8;
-        } else {
-        	int stride;
-            pix_fmt = AV_PIX_FMT_GRAY8;
-            /* special case for gray8, and planar outputs, don't need to scale, 
-               can use a neutral array */
-            switch (c->pix_fmt) {
-    			case AV_PIX_FMT_YUV420P:   //< planar YUV 4:2:0, 12bpp, (1 Cr & Cb sample per 2x2 Y samples)
-    			case AV_PIX_FMT_YUV411P:   //< planar YUV 4:1:1, 12bpp, (1 Cr & Cb sample per 4x1 Y samples)
-    			case AV_PIX_FMT_YUVJ420P:  //< planar YUV 4:2:0, 12bpp, full scale (JPEG), deprecated in favor of AV_PIX_FMT_YUV420P and setting color_range
-    			case AV_PIX_FMT_NV12:      //< planar YUV 4:2:0, 12bpp, 1 plane for Y and 1 plane for the UV components, which are interleaved (first byte U and the following byte V)
-    			case AV_PIX_FMT_NV21:      //< as above, but U and V bytes are swapped
-    				stride = 4;
-    				break;
-    			case AV_PIX_FMT_YUV422P:   //< planar YUV 4:2:2, 16bpp, (1 Cr & Cb sample per 2x1 Y samples)
-    			case AV_PIX_FMT_YUVJ422P:  //< planar YUV 4:2:2, 16bpp, full scale (JPEG), deprecated in favor of AV_PIX_FMT_YUV422P and setting color_range
-    			case AV_PIX_FMT_YUV440P:   //< planar YUV 4:4:0 (1 Cr & Cb sample per 1x2 Y samples)
-    			case AV_PIX_FMT_YUVJ440P:  //< planar YUV 4:4:0 full scale (JPEG), deprecated in favor of AV_PIX_FMT_YUV440P and setting color_range    			
-    				stride = 2;
-    				break;    				
-    			case AV_PIX_FMT_YUV444P:   //< planar YUV 4:4:4, 24bpp, (1 Cr & Cb sample per 1x1 Y samples)    			
-    			case AV_PIX_FMT_YUVJ444P:  //< planar YUV 4:4:4, 24bpp, full scale (JPEG), deprecated in favor of AV_PIX_FMT_YUV444P and setting color_range
-					stride = 1;
-    				break;	
-    			default:
-    				stride = 0;
-    				break;				
-			}			
-			if (stride) {	
-				scPicture->format = c->pix_fmt;
-				scPicture->width = c->width;
-				scPicture->height = c->height;
-	    	    scPicture->data[0] = (uint8_t*) pArray->pData;
-    		    scPicture->data[1] = (uint8_t*) neutral;
-    		    scPicture->data[2] = (uint8_t*) neutral;    	        	    
-		        scPicture->linesize[0] = width;
-		        scPicture->linesize[1] = width / stride;
-		        scPicture->linesize[2] = width / stride;
-				return(asynSuccess);		        
-		    }
-		}
+        pix_fmt = Int16 ? AV_PIX_FMT_GRAY16 : AV_PIX_FMT_GRAY8;
+
         /* setup the input picture */
         inPicture->data[0] = (uint8_t*) pArray->pData;
         inPicture->linesize[0] = width * (Int16 + 1);


### PR DESCRIPTION
With the mjpeg codec in use at Diamond, we have been seeing the following crash:

`Assertion ((src_linesize) >= 0 ? (src_linesize) : (-(src_linesize))) >= bytewidth failed at src/libavutil/imgutils.c:350`

for 8 bit mono images when entering the logic block that returns early from formatArray without performing `sws_scale`. This crash did not occur before the deprecated API calls were replaced. With some quick benchmarks on my workstation I couldn't see any appreciable change in cpu usage when bypassing this logic, @coretl and I discussed that the simplest solution may be to just scale all images to prevent this crash, though if there are other suggestions I can amend this - for the specific codec I have been testing with the crash can be avoided by setting the `stride` variable to 2 or 1. 